### PR TITLE
解决linux图像模式code :2问题

### DIFF
--- a/src/main/java/com/arcsoft/face/FaceLibrary.java
+++ b/src/main/java/com/arcsoft/face/FaceLibrary.java
@@ -64,7 +64,7 @@ public interface FaceLibrary extends Library {
 	 *            [out] 初始化返回的引擎handle
 	 * @return 成功返回MOK，失败返回错误码，参考{@link com.arcsoft.face.enums.ErrorCode}
 	 */
-	NativeLong ASFInitEngine(int detectMode, int detectFaceOrientPriority, int detectFaceScaleVal, int detectFaceMaxNum,
+	NativeLong ASFInitEngine(long detectMode, int detectFaceOrientPriority, int detectFaceScaleVal, int detectFaceMaxNum,
 			int combinedMask, PointerByReference phEngine);
 
 	/**

--- a/src/main/java/com/arcsoft/face/enums/DetectMode.java
+++ b/src/main/java/com/arcsoft/face/enums/DetectMode.java
@@ -11,9 +11,9 @@ public interface DetectMode {
 	/**
 	 * 视频模式
 	 */
-	int ASF_DETECT_MODE_VIDEO = 0x00000000;
+	long ASF_DETECT_MODE_VIDEO = 0x00000000L;
 	/**
 	 * 图片模式
 	 */
-	int ASF_DETECT_MODE_IMAGE = 0xFFFFFFFF;
+	long ASF_DETECT_MODE_IMAGE = 0xFFFFFFFFL;
 }


### PR DESCRIPTION
arcface版本: 2.0
linux环境: 阿里云centos7
问题: 在图像模式下引擎初始化失败, 错误代码 code :2
解决: 推断是int数据格式溢出导致的问题, 改为long问题解决
验证: 修改后win7环境下正常, centos7下正常

希望大神merge解决一下, 多谢提供这么好的demo, 感谢!

![image](https://user-images.githubusercontent.com/24547457/53459165-c73fad80-3a73-11e9-9059-c694b435af20.png)
